### PR TITLE
Add Mica effect, titlebar customization

### DIFF
--- a/tukaan/__init__.py
+++ b/tukaan/__init__.py
@@ -15,4 +15,4 @@ from .separator import Separator
 from .slider import Slider
 from .textbox import TextBox
 from .timeout import Timeout
-from .window import App, DwmBlurEffect, Window
+from .window import App, Window

--- a/tukaan/__init__.py
+++ b/tukaan/__init__.py
@@ -15,4 +15,4 @@ from .separator import Separator
 from .slider import Slider
 from .textbox import TextBox
 from .timeout import Timeout
-from .window import App, Window
+from .window import App, Window, DwmBlurEffect

--- a/tukaan/__init__.py
+++ b/tukaan/__init__.py
@@ -15,4 +15,4 @@ from .separator import Separator
 from .slider import Slider
 from .textbox import TextBox
 from .timeout import Timeout
-from .window import App, Window, DwmBlurEffect
+from .window import App, DwmBlurEffect, Window

--- a/tukaan/_base.py
+++ b/tukaan/_base.py
@@ -197,10 +197,7 @@ class CommonMethods:
         self._tcl_call(None, "focus", self)
 
     def hide(self):
-        if self.tcl_path == ".app" or self._class == "Toplevel":
-            # object is a window
-            self._tcl_call(None, "wm", "withdraw", self.wm_path)
-        elif self.layout._real_manager == "grid":
+        if self.layout._real_manager == "grid":
             # widget managed by grid
             self._tcl_call(None, "grid", "remove", self.tcl_path)
         elif self.layout._real_manager == "place":
@@ -215,12 +212,7 @@ class CommonMethods:
             self._tcl_call(None, "place", "forget", self.tcl_path)
 
     def unhide(self):
-        from .window import App, Window
-
-        if isinstance(self, (App, Window)):
-            # object is a window
-            self._tcl_call(None, "wm", "deiconify", self.wm_path)
-        elif self.layout._real_manager == "grid":
+        if self.layout._real_manager == "grid":
             # widget managed by grid
             self._tcl_call(None, "grid", "configure", self.tcl_path)
         elif self.layout._real_manager == "place":

--- a/tukaan/_platform.py
+++ b/tukaan/_platform.py
@@ -7,6 +7,14 @@ import _tkinter as tk
 from ._utils import ClassPropertyMetaClass, classproperty, get_tcl_interp
 
 
+def windows_only(func):
+    def wrapper(*args, **kwargs):
+        if platform.system() == "Windows":
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
 class Platform(metaclass=ClassPropertyMetaClass):
     version: str = platform.version()
     node: str = platform.node()

--- a/tukaan/window.py
+++ b/tukaan/window.py
@@ -324,7 +324,7 @@ class TkWindowManager(DesktopWindowManager):
             if self._winsys == "x11":
                 self._tcl_call(None, "wm", "attributes", self.wm_path, "-zoomed", False)
             else:
-                self._tcl_call(None, "wm", "state", self.wm_path, "normal")            
+                self._tcl_call(None, "wm", "state", self.wm_path, "normal")
         elif state == "fullscreen":
             self._tcl_call(None, "wm", "attributes", self.wm_path, "-fullscreen", False)
 
@@ -350,7 +350,7 @@ class TkWindowManager(DesktopWindowManager):
 
     @property
     def _wm_frame(self):
-        return int(self._tcl_call(str, 'wm', 'frame', self.wm_path), 16)
+        return int(self._tcl_call(str, "wm", "frame", self.wm_path), 16)
 
     @property
     def state(self):

--- a/tukaan/window.py
+++ b/tukaan/window.py
@@ -127,27 +127,25 @@ class Titlebar:
 
     def get_bg_color(self) -> Color:
         if self._bg_color is not None:
-            return Color(rgb=self._bg_color)
+            return Color(self._bg_color)
 
     @windows_only
     def set_bg_color(self, color: Color) -> None:
-        color = color.hex
+        self._bg_color = color = color.hex
         int_color = int(color[5:7] + color[3:5] + color[1:3], 16)
         self._window._dwm_set_window_attribute(DWMWA_CAPTION_COLOR, int_color)
-        self._bg_color = color.rgb
 
     bg_color = property(get_bg_color, set_bg_color)
 
     def get_fg_color(self) -> Color:
         if self._fg_color is not None:
-            return Color(rgb=self._fg_color)
+            return Color(self._fg_color)
 
     @windows_only
     def set_fg_color(self, color: Color) -> None:
-        color = color.hex
+        self._fg_color = color = color.hex
         int_color = int(color[5:7] + color[3:5] + color[1:3], 16)
         self._window._dwm_set_window_attribute(DWMWA_TEXT_COLOR, int_color)
-        self._fg_color = color.rgb
 
     fg_color = property(get_fg_color, set_fg_color)
 
@@ -196,14 +194,13 @@ class DesktopWindowManager:
 
     def get_border_color(self) -> Color:
         if self._border_color is not None:
-            return Color(rgb=self._border_color)
+            return Color(self._border_color)
 
     @windows_only
     def set_border_color(self, color: Color) -> None:
-        color = color.hex
+        self._border_color = color = color.hex
         int_color = int(color[5:7] + color[3:5] + color[1:3], 16)
         self._window._dwm_set_window_attribute(DWMWA_BORDER_COLOR, int_color)
-        self._border_color = color.rgb
 
     border_color = property(get_border_color, set_border_color)
 

--- a/tukaan/window.py
+++ b/tukaan/window.py
@@ -153,23 +153,18 @@ class Titlebar:
 class DesktopWindowManager:
     _border_color = None
 
-    @property
-    @windows_only
-    def HWND(self) -> int:
-        return ctypes.windll.user32.GetParent(self.id)
-
     def _dwm_set_window_attribute(self, rendering_policy: int, value: Any) -> None:
         value = ctypes.c_int(value)
 
         ctypes.windll.dwmapi.DwmSetWindowAttribute(
-            self.HWND,
+            self._wm_frame,
             rendering_policy,
             ctypes.byref(value),
             ctypes.sizeof(value),
         )
 
     def _set_window_composition_attribute(self, wcad: WindowCompositionAttributeData) -> None:
-        ctypes.windll.user32.SetWindowCompositionAttribute(self.HWND, wcad)
+        ctypes.windll.user32.SetWindowCompositionAttribute(self._wm_frame, wcad)
 
     def get_preview_disabled(self) -> bool:
         return self._is_preview_disabled
@@ -362,6 +357,8 @@ class TkWindowManager(DesktopWindowManager):
         return wrapper
 
     @property
+    def _wm_frame(self):
+        return int(self._tcl_call(str, 'wm', 'frame', self.wm_path), 16)
     def is_focused(self) -> int:
         return self._tcl_call(str, "focus", "-displayof", self.wm_path)
 

--- a/tukaan/window.py
+++ b/tukaan/window.py
@@ -222,7 +222,7 @@ class DesktopWindowManager:
             "acrylic": 4,
             "mica": 5,
         }[effect]
-        
+
         build = sys.getwindowsversion().build
         has_mica = build >= 22000
         has_backdrop_type = build >= 22523

--- a/tukaan/window.py
+++ b/tukaan/window.py
@@ -73,6 +73,7 @@ class WindowCompositionAttributeData(ctypes.Structure):
 
 class DesktopWindowManager:
     """Interface for Windows DWM functions"""
+
     _tcl_call: Callable
     _tcl_eval: Callable
     wm_path: str
@@ -103,7 +104,7 @@ class DesktopWindowManager:
         return self._is_immersive_dark_mode_used
 
     @update_before
-    def set_immersive_dark_mode(self, is_used: bool=False) -> None:
+    def set_immersive_dark_mode(self, is_used: bool = False) -> None:
         self._dwm_set_window_attribute(self.DWMWA_USE_IMMERSIVE_DARK_MODE, int(is_used))
 
         # Need to redraw the titlebar
@@ -120,7 +121,7 @@ class DesktopWindowManager:
         return self._is_rtl_titlebar_used
 
     @update_before
-    def set_rtl_titlebar(self, is_used: bool=False) -> None:
+    def set_rtl_titlebar(self, is_used: bool = False) -> None:
         self._dwm_set_window_attribute(self.DWMWA_NONCLIENT_RTL_LAYOUT, int(is_used))
 
         self._is_rtl_titlebar_used = is_used
@@ -131,7 +132,7 @@ class DesktopWindowManager:
         return self._is_preview_disabled
 
     @update_before
-    def set_preview_disabled(self, is_disabled: bool=False) -> None:
+    def set_preview_disabled(self, is_disabled: bool = False) -> None:
         self._dwm_set_window_attribute(self.DWMWA_FORCE_ICONIC_REPRESENTATION, int(is_disabled))
 
         self._is_preview_disabled = is_disabled
@@ -141,7 +142,7 @@ class DesktopWindowManager:
     def get_tool_window(self) -> bool:
         return self._tcl_call(bool, "wm", "attributes", self.wm_path, "-toolwindow")
 
-    def set_tool_window(self, is_toolwindow: bool=False) -> None:
+    def set_tool_window(self, is_toolwindow: bool = False) -> None:
         self._tcl_call(None, "wm", "attributes", self.wm_path, "-toolwindow", is_toolwindow)
 
     tool_window = property(get_tool_window, set_tool_window)

--- a/tukaan/window.py
+++ b/tukaan/window.py
@@ -222,11 +222,12 @@ class DesktopWindowManager:
             "acrylic": 4,
             "mica": 5,
         }[effect]
+        
         build = sys.getwindowsversion().build
         has_mica = build >= 22000
         has_backdrop_type = build >= 22523
 
-        if has_mica or has_backdrop_type and effect == 5:
+        if not has_mica and effect == 5:
             # Mica is available only on Windows 11 build 22000+, fall back to acrylic
             effect = 4
 

--- a/tukaan/window.py
+++ b/tukaan/window.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ctypes
 import os
 import platform
 import re
@@ -15,6 +16,7 @@ from ._base import BaseWidget, TkWidget
 from ._constants import _resizable
 from ._images import _image_converter_class
 from ._layouts import BaseLayoutManager
+from ._misc import Color
 from ._utils import _callbacks, from_tcl, reversed_dict, to_tcl
 from .exceptions import TclError
 
@@ -52,7 +54,180 @@ def update_after(func: Callable) -> Callable:
     return wrapper
 
 
-class WindowManager:
+class AccentPolicy(ctypes.Structure):
+    _fields_ = [
+        ("AccentState", ctypes.c_int),
+        ("AccentFlags", ctypes.c_int),
+        ("GradientColor", ctypes.c_uint),
+        ("AnimationId", ctypes.c_int),
+    ]
+
+
+class WindowCompositionAttributeData(ctypes.Structure):
+    _fields_ = [
+        ("Attribute", ctypes.c_int),
+        ("Data", ctypes.POINTER(ctypes.c_int)),
+        ("SizeOfData", ctypes.c_size_t),
+    ]
+
+
+class DesktopWindowManager:
+    """Interface for Windows DWM functions"""
+    _tcl_call: Callable
+    _tcl_eval: Callable
+    wm_path: str
+
+    DWMWA_TRANSITIONS_FORCEDISABLED = 3
+    DWMWA_NONCLIENT_RTL_LAYOUT = 6
+    DWMWA_FORCE_ICONIC_REPRESENTATION = 7
+    DWMWA_USE_IMMERSIVE_DARK_MODE = 20
+
+    @property
+    def HWND(self) -> int:
+        return ctypes.windll.user32.GetParent(self.id)
+
+    def _dwm_set_window_attribute(self, rendering_policy: int, value: Any) -> None:
+        value = ctypes.c_int(value)
+
+        ctypes.windll.dwmapi.DwmSetWindowAttribute(
+            self.HWND,
+            rendering_policy,
+            ctypes.byref(value),
+            ctypes.sizeof(value),
+        )
+
+    def _set_window_composition_attribute(self, wcad: WindowCompositionAttributeData) -> None:
+        ctypes.windll.user32.SetWindowCompositionAttribute(self.HWND, wcad)
+
+    def get_immersive_dark_mode(self) -> bool:
+        return self._is_immersive_dark_mode_used
+
+    @update_before
+    def set_immersive_dark_mode(self, is_used: bool=False) -> None:
+        self._dwm_set_window_attribute(self.DWMWA_USE_IMMERSIVE_DARK_MODE, int(is_used))
+
+        # Need to redraw the titlebar
+        self._dwm_set_window_attribute(self.DWMWA_TRANSITIONS_FORCEDISABLED, 1)
+        self.minimize()
+        self.restore()
+        self._dwm_set_window_attribute(self.DWMWA_TRANSITIONS_FORCEDISABLED, 0)
+
+        self._is_immersive_dark_mode_used = is_used
+
+    immersive_dark_mode = property(get_immersive_dark_mode, set_immersive_dark_mode)
+
+    def get_rtl_titlebar(self) -> bool:
+        return self._is_rtl_titlebar_used
+
+    @update_before
+    def set_rtl_titlebar(self, is_used: bool=False) -> None:
+        self._dwm_set_window_attribute(self.DWMWA_NONCLIENT_RTL_LAYOUT, int(is_used))
+
+        self._is_rtl_titlebar_used = is_used
+
+    rtl_titlebar = property(get_rtl_titlebar, set_rtl_titlebar)
+
+    def get_preview_disabled(self) -> bool:
+        return self._is_preview_disabled
+
+    @update_before
+    def set_preview_disabled(self, is_disabled: bool=False) -> None:
+        self._dwm_set_window_attribute(self.DWMWA_FORCE_ICONIC_REPRESENTATION, int(is_disabled))
+
+        self._is_preview_disabled = is_disabled
+
+    preview_disabled = property(get_preview_disabled, set_preview_disabled)
+
+    def get_tool_window(self) -> bool:
+        return self._tcl_call(bool, "wm", "attributes", self.wm_path, "-toolwindow")
+
+    def set_tool_window(self, is_toolwindow: bool=False) -> None:
+        self._tcl_call(None, "wm", "attributes", self.wm_path, "-toolwindow", is_toolwindow)
+
+    tool_window = property(get_tool_window, set_tool_window)
+
+    def enable_bg_blur(
+        self, tint: Optional[Color] = None, tint_opacity: float = 0.2, accent_state: int = 3
+    ) -> None:
+        # https://github.com/Peticali/PythonBlurBehind/blob/main/blurWindow/blurWindow.py
+        # https://github.com/sourcechord/FluentWPF/blob/master/FluentWPF/Utility/AcrylicHelper.cs
+
+        # Make an ABGR color from `tint` and `tint_opacity`
+        # If `tint` is None, use the window background color
+        bg_color = self._tcl_eval(str, "ttk::style lookup . -background")
+
+        if tint is None:
+            tint = Color(
+                rgb=tuple(value >> 8 for value in self._tcl_eval((int,), f"winfo rgb . {bg_color}"))
+            ).hex
+
+        tint_alpha = str(hex(int(255 * tint_opacity)))[2:]
+        tint_hex_bgr = tint[5:7] + tint[3:5] + tint[1:3]
+
+        # Set up AccentPolicy struct
+        ap = AccentPolicy()
+        ap.AccentFlags = 2  # ACCENT_ENABLE_BLURBEHIND  <- try this with 4 bruhh :D
+        ap.AccentState = accent_state
+        ap.GradientColor = int(tint_alpha + tint_hex_bgr, 16)
+
+        # Set up WindowCompositionAttributeData struct
+        wcad = WindowCompositionAttributeData()
+        wcad.Attribute = 19  # WCA_ACCENT_POLICY
+        wcad.Data = ctypes.cast(ctypes.pointer(ap), ctypes.POINTER(ctypes.c_int))
+        wcad.SizeOfData = ctypes.sizeof(ap)
+
+        self._set_window_composition_attribute(wcad)
+
+        # Make the window background, and each pixel with the same colour as the window background fully transparent
+        # These are the areas that will be blurred
+        self._tcl_eval(None, f"wm attributes {self.wm_path} -transparentcolor {bg_color}")
+
+        # When the window has `transparentcolor`, the whole window becomes unusable after unmaximizing
+        # Therefore we bind it to the expose event, so every time it changes state, it calls the _fullredraw method
+        # See _fullredraw.__doc__ for more
+        self._prev_state = self._tcl_call(str, "wm", "state", self.wm_path)
+        self.events.bind("<Expose>", self._fullredraw)
+
+    def disable_bg_blur(self) -> None:
+        # Set up AccentPolicy struct
+        ap = AccentPolicy()
+        ap.AccentFlags = 0  # idk
+        ap.AccentState = 0  # ACCENT_DISABLED
+        ap.GradientColor = 0
+
+        # Set up WindowCompositionAttributeData struct
+        wcad = WindowCompositionAttributeData()
+        wcad.Attribute = 19  # WCA_ACCENT_POLICY
+        wcad.Data = ctypes.cast(ctypes.pointer(ap), ctypes.POINTER(ctypes.c_int))
+        wcad.SizeOfData = ctypes.sizeof(ap)
+
+        self._set_window_composition_attribute(wcad)
+
+        # Remove `-transparentcolor`
+        self._tcl_eval(None, f"wm attributes {self.wm_path} -transparentcolor {{}}")
+
+        # Remove <Expose> binding
+        self.events.unbind("<Expose>")
+
+    def _fullredraw(self) -> None:
+        """
+        Internal method
+
+        Neither user32.RedrawWindow nor user32.UpdateWindow redraws the titlebar,
+        so we need to explicitly minimize and then restore the window.
+        To avoid visual effects, disable transitions on the window for that time.
+        """
+
+        if self._prev_state == "zoomed":
+            self._dwm_set_window_attribute(self.DWMWA_TRANSITIONS_FORCEDISABLED, 1)
+            self.minimize()
+            self.restore()
+            self._dwm_set_window_attribute(self.DWMWA_TRANSITIONS_FORCEDISABLED, 0)
+
+        self._prev_state = self._tcl_call(str, "wm", "state", self.wm_path)
+
+
+class TkWindowManager(DesktopWindowManager):
     _tcl_call: Callable
     _tcl_eval: Callable
     _winsys: str
@@ -91,10 +266,10 @@ class WindowManager:
     def focus(self) -> None:
         self._tcl_call(None, "focus", "-force", self.wm_path)
 
-    def group(self, other: WindowManager) -> None:
+    def group(self, other: TkWindowManager) -> None:
         self._tcl_call(None, "wm", "group", self.wm_path, other.tcl_path)
 
-    def on_close(self, func: Callable[[WindowManager], None]) -> Callable[[], None]:
+    def on_close(self, func: Callable[[TkWindowManager], None]) -> Callable[[], None]:
         def wrapper() -> None:
             if func(self):
                 self.destroy()
@@ -316,10 +491,10 @@ class WindowManager:
 
     icon = property(get_icon, set_icon)
 
-    def get_on_close_callback(self) -> Callable[[WindowManager], None]:
+    def get_on_close_callback(self) -> Callable[[TkWindowManager], None]:
         return _callbacks[self._tcl_call(str, "wm", "protocol", self.wm_path, "WM_DELETE_WINDOW")]
 
-    def set_on_close_callback(self, callback: Callable[[WindowManager], None]) -> None:
+    def set_on_close_callback(self, callback: Callable[[TkWindowManager], None]) -> None:
         self._tcl_call(None, "wm", "protocol", self.wm_path, "WM_DELETE_WINDOW", callback)
 
     on_close_callback = property(get_on_close_callback, set_on_close_callback)
@@ -332,77 +507,8 @@ class WindowManager:
 
     scaling = property(get_scaling, set_scaling)
 
-    # Platform specific things
 
-    def _dwm_set_window_attribute(self, rendering_policy, value):
-        """
-        Windows only feature
-
-        The idea of these windll and dwm stuff came from this Gist by Olikonsti:
-        https://gist.github.com/Olikonsti/879edbf69b801d8519bf25e804cec0aa
-        """
-
-        from ctypes import byref, c_int, sizeof, windll
-
-        value = c_int(value)
-
-        windll.dwmapi.DwmSetWindowAttribute(
-            windll.user32.GetParent(self.id), rendering_policy, byref(value), sizeof(value)
-        )
-
-    def get_immersive_dark_mode(self):
-        return self._is_immersive_dark_mode_used
-
-    @update_before
-    def set_immersive_dark_mode(self, is_used=False):
-        rendering_policy = 20  # DWMWA_USE_IMMERSIVE_DARK_MODE
-
-        self._dwm_set_window_attribute(rendering_policy, int(is_used))
-
-        self._is_immersive_dark_mode_used = is_used
-
-        # Need to redraw the titlebar
-        self.minimize()
-        self.restore()
-
-    immersive_dark_mode = property(get_immersive_dark_mode, set_immersive_dark_mode)
-
-    def get_rtl_titlebar(self):
-        return self._is_rtl_titlebar_used
-
-    @update_before
-    def set_rtl_titlebar(self, is_used=False):
-        rendering_policy = 6  # DWMWA_NONCLIENT_RTL_LAYOUT
-
-        self._dwm_set_window_attribute(rendering_policy, int(is_used))
-
-        self._is_rtl_titlebar_used = is_used
-
-    rtl_titlebar = property(get_rtl_titlebar, set_rtl_titlebar)
-
-    def get_preview_disabled(self):
-        return self._is_preview_disabled
-
-    @update_before
-    def set_preview_disabled(self, is_disabled=False):
-        rendering_policy = 7  # DWMWA_FORCE_ICONIC_REPRESENTATION
-
-        self._dwm_set_window_attribute(rendering_policy, int(is_disabled))
-
-        self._is_preview_disabled = is_disabled
-
-    preview_disabled = property(get_preview_disabled, set_preview_disabled)
-
-    def get_tool_window(self):
-        return self._tcl_call(bool, "wm", "attributes", self.wm_path, "-toolwindow")
-
-    def set_tool_window(self, is_toolwindow=False):
-        self._tcl_call(None, "wm", "attributes", self.wm_path, "-toolwindow", is_toolwindow)
-
-    tool_window = property(get_tool_window, set_tool_window)
-
-
-class App(WindowManager, TkWidget):
+class App(TkWindowManager, TkWidget):
     wm_path = "."
     tcl_path = ".app"
 
@@ -555,7 +661,7 @@ class App(WindowManager, TkWidget):
         self._tcl_call(None, "ttk::style", "theme", "use", self._get_theme_aliases()[theme])
 
 
-class Window(WindowManager, BaseWidget):
+class Window(TkWindowManager, BaseWidget):
     _tcl_class = "toplevel"
     _keys = {}
 

--- a/tukaan/window.py
+++ b/tukaan/window.py
@@ -200,7 +200,7 @@ class DesktopWindowManager:
     def set_border_color(self, color: Color) -> None:
         self._border_color = color = color.hex
         int_color = int(color[5:7] + color[3:5] + color[1:3], 16)
-        self._window._dwm_set_window_attribute(DWMWA_BORDER_COLOR, int_color)
+        self._dwm_set_window_attribute(DWMWA_BORDER_COLOR, int_color)
 
     border_color = property(get_border_color, set_border_color)
 


### PR DESCRIPTION
Hi!

Could someone with Windows 11 build 22000 or above test the following two snippets for me?

I don't have this build, and installing a new Windows build is kinda pain, so I'd be really grateful, if you someone could test them, and give feedback. Thanks!

You can just download the `2022-02-16` branch, and run this two code to test it.

### Mica

This code should add a Mica effect to the window, and remove it after 10 seconds.
```python
import tukaan

app = tukaan.App(title="Test titlebar and window border customization")

app.set_backdrop_effect("mica")

tukaan.Timeout(10, lambda: app.set_backdrop_effect(None)).start()

app.run()

```

### Titlebar bg, fg and window border:
```python
import tukaan

app = tukaan.App(title="Test titlebar and window border customization")

app.Titlebar.bg_color = tukaan.Color("#ffc568")
app.Titlebar.fg_color = tukaan.Color("#6667ab")
app.border_color = tukaan.Color("#007fff")

app.run()
```
I'm not sure, if I implemented the bg, fg and border color functions correctly, and the colors may be something completely else. Here's how they should look:
 asdf | color
--- | ---
titlebar should be this color | ![ffc568](https://user-images.githubusercontent.com/77941087/154745481-90a204f1-1b70-4738-be21-3ca027a9cd7d.png)
titlebar text should be this color | ![6667ab](https://user-images.githubusercontent.com/77941087/154745440-fdada50b-c1f2-4ecc-b693-b3315304ec48.png)
window border should be this color | ![007fff](https://user-images.githubusercontent.com/77941087/154745530-d8b272be-77df-40a5-8a7f-e28e9f7840b5.png)

