### PR TITLE
Add Gtk theming

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "tukaan/Snack"]
 	path = tukaan/Snack
 	url = https://github.com/tukaan/Snack
+[submodule "tukaan/Gttk"]
+	path = tukaan/Gttk
+	url = https://github.com/tukaan/Gttk

--- a/tukaan/_font.py
+++ b/tukaan/_font.py
@@ -221,7 +221,7 @@ class Font:
         self._set("overstrike", value)
 
     @property
-    def families(cls):
+    def families(cls) -> list[str]:
         return sorted(list(set(Tcl.call([str], "font", "families"))))  # set to remove duplicates
 
     def measure(self, text: str) -> int:

--- a/tukaan/_layouts.py
+++ b/tukaan/_layouts.py
@@ -143,7 +143,7 @@ class Grid:
         padx, pady = self._parse_margin(margin)
 
         if align and not any((hor_align, vert_align)):
-            hor_align, vert_align = (align,) * 2  # type: ignore
+            hor_align, vert_align = align
         elif align:
             raise LayoutError("both align and hor_align and/or vert_align given")
 
@@ -206,7 +206,7 @@ class Grid:
         try:
             result = StickyValues((hor, vert)).name
             return result if result != "none" else ""
-        except KeyError:
+        except ValueError:
             raise LayoutError(f"invalid alignment value: {(hor, vert)}")
 
     def _get_sticky_values(self, key: str) -> tuple[HorAlignAlias, VertAlignAlias]:

--- a/tukaan/_tcl.py
+++ b/tukaan/_tcl.py
@@ -142,9 +142,7 @@ class Tcl:
     @staticmethod
     def call(return_type: Any, *args) -> Any:
         try:
-            _args = tuple(map(Tcl.to, args))
-            print(_args)  # TODO: remove
-            result = _tcl_interp.call(*_args)
+            result = _tcl_interp.call(*map(Tcl.to, args))
             if return_type is None:
                 return
             return Tcl.from_(return_type, result)

--- a/tukaan/_utils.py
+++ b/tukaan/_utils.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from ._font import Font
     from ._images import Icon, _image_converter_class
     from ._variables import _TclVariable
-    from .media import Sound
+    from .audio import Sound
     from .textbox import Tag
     from .timeout import Timeout
 

--- a/tukaan/themes/__init__.py
+++ b/tukaan/themes/__init__.py
@@ -1,1 +1,1 @@
-from .themes import AquaTheme, ClamTheme, Theme, Win32Theme, native_theme
+from .themes import AquaTheme, ClamTheme, GtkTheme, Theme, Win32Theme, native_theme

--- a/tukaan/themes/themes.py
+++ b/tukaan/themes/themes.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
 from abc import ABC, abstractclassmethod
 
 from tukaan._info import System
 from tukaan._tcl import Tcl
-from tukaan._utils import mac_only, windows_only
+from tukaan._utils import linux_only, mac_only, windows_only
+from tukaan.exceptions import TclError
+
+
+class ThemeError(Exception):
+    ...
 
 
 class Theme(ABC):
@@ -17,13 +24,6 @@ class ClamTheme(Theme):
         Tcl.call(None, "ttk::style", "theme", "use", "clam")
 
 
-class Win32Theme(Theme):
-    @classmethod
-    @windows_only
-    def _use(cls):
-        Tcl.call(None, "ttk::style", "theme", "use", "vista")
-
-
 class AquaTheme(Theme):
     @classmethod
     @mac_only
@@ -31,9 +31,47 @@ class AquaTheme(Theme):
         Tcl.call(None, "ttk::style", "theme", "use", "aqua")
 
 
-def native_theme() -> Theme:
+class GtkTheme(Theme):
+    __theme = None
+
+    def __init__(self, theme: str | None = None) -> None:
+        GtkTheme.__theme = theme
+
+    @classmethod
+    @linux_only
+    def _use(cls) -> None:
+        Tcl.call(None, "ttk::style", "theme", "use", "Gttk")
+        if not cls.__theme:
+            return
+
+        try:
+            Tcl.call(None, "ttk::theme::Gttk::setGtkTheme", cls.__theme)
+        except TclError:
+            raise ThemeError(f"invalid GTK theme name: {cls.__theme}")
+
+    @classmethod
+    @linux_only
+    def get_themes(cls) -> list[str]:
+        return sorted(Tcl.call([str], "ttk::theme::Gttk::availableGtkThemes"))
+
+    @classmethod
+    @linux_only
+    def get_system_theme(cls) -> str:
+        return Tcl.call(str, "ttk::theme::Gttk::currentThemeName")
+
+
+class Win32Theme(Theme):
+    @classmethod
+    @windows_only
+    def _use(cls):
+        Tcl.call(None, "ttk::style", "theme", "use", "vista")
+
+
+def native_theme(use_gtk: bool = True) -> Theme:
     if System.os == "Windows":
         return Win32Theme
     elif System.os == "macOS":
         return AquaTheme
+    elif System.os == "Linux" and use_gtk:
+        return GtkTheme
     return ClamTheme

--- a/tukaan/widgets/radiobutton.py
+++ b/tukaan/widgets/radiobutton.py
@@ -119,4 +119,4 @@ class RadioGroup(Frame, InputControlWidget):
         for index, (id, text) in enumerate(tuple(new_items.items())):
             radio = RadioButton(self, variable=self.variable, value=id, text=text)
             radio.item_id = id
-            radio.layout.grid(row=index)
+            radio.layout.grid(row=index, hor_align="left")

--- a/tukaan/window.py
+++ b/tukaan/window.py
@@ -13,6 +13,7 @@ from tukaan.themes import AquaTheme, ClamTheme, Theme, Win32Theme, native_theme
 
 from ._enums import BackdropEffect, Resizable
 from ._images import _image_converter_class
+from ._info import System
 from ._layouts import ContainerLayoutManager
 from ._structures import Color, Position, Size
 from ._tcl import Tcl
@@ -655,11 +656,14 @@ class App(WindowMixin, TkWidget):
         Tcl.call(None, "bind", self._name, "<Unmap>", self._generate_state_event)
         Tcl.call(None, "bind", self._name, "<Configure>", self._generate_state_event)
 
+        self._init_tkdnd()
         self._init_tukaan_ext_pkg("Serif")
         self._init_tukaan_ext_pkg("Snack")
-        self._init_tkdnd()
 
-        self.theme = native_theme()
+        if System.os == "Linux":
+            self._init_tukaan_ext_pkg("Gttk")
+
+        self.theme = native_theme(use_gtk=False)
 
         Tcl.call(None, "wm", "protocol", self._wm_path, "WM_DELETE_WINDOW", self.destroy)
 


### PR DESCRIPTION
# Gtk themes for Tukaan

## Basics
```python
from tukaan.themes import GtkTheme

app.theme = GtkTheme  # Native Gtk theme

app.theme = GtkTheme("Adwaita")  # Select which Gtk theme to use
```

## Even more stuff
```python
>>> from tukaan.themes import GtkTheme

>>> print(GtkTheme.themes)  # Returns the Gtk themes available on the system
['Adwaita', 'Breeze', 'Breeze-Dark', 'Dracula', 'Raleigh', 'Yaru-dark', 'Yaru-light']

>>> print(GtkTheme.system_theme)  # Get the system's active Gtk theme
'Yaru-dark'
```