### PR TITLE
change: use properties & descriptors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ screeninfo>=0.8
 libtukaan-win==0.1.2; sys_platform == "win32"
 libtukaan-mac==0.1.2; sys_platform == "darwin"
 libtukaan-unix==0.1.2; sys_platform == "linux"
+typing_extensions>=4.3.0; python_version < "3.9"

--- a/tukaan/_base.py
+++ b/tukaan/_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import collections
-from typing import Callable, TypeVar
+from typing import Callable
 
 from ._events import EventMixin
 from ._layout import ContainerGrid, Geometry, Grid, Position, ToplevelGrid
@@ -11,10 +11,6 @@ from ._tcl import Tcl
 from ._utils import _commands, _widgets, count
 from ._wm import WindowManager
 from .widgets.tooltip import ToolTipProvider
-
-T = TypeVar("T")
-T_co = TypeVar("T_co", covariant=True)
-T_contra = TypeVar("T_contra", contravariant=True)
 
 
 def generate_pathname(widget: TkWidget, parent: TkWidget) -> str:

--- a/tukaan/_base.py
+++ b/tukaan/_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import collections
-from typing import Callable
+from typing import Callable, TypeVar
 
 from ._events import EventMixin
 from ._layout import ContainerGrid, Geometry, Grid, Position, ToplevelGrid
@@ -11,6 +11,10 @@ from ._tcl import Tcl
 from ._utils import _commands, _widgets, count
 from ._wm import WindowManager
 from .widgets.tooltip import ToolTipProvider
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
 
 
 def generate_pathname(widget: TkWidget, parent: TkWidget) -> str:

--- a/tukaan/_behaviour.py
+++ b/tukaan/_behaviour.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
-
 
 class instanceclassmethod:
     def __init__(self, method) -> None:
         self.method = method
 
-    def __get__(self, obj: Any | None, objtype: type):
+    def __get__(self, obj: object | None, objtype: type):
         def wrapper(*args, **kwargs):
             if obj is None:
                 return self.method(objtype, *args, **kwargs)
@@ -22,5 +20,5 @@ class classproperty:
             fget = classmethod(fget)
         self.fget = fget
 
-    def __get__(self, obj: Any | None, objtype: type):
+    def __get__(self, obj: object | None, objtype: type):
         return self.fget.__get__(obj, objtype)()

--- a/tukaan/_events.py
+++ b/tukaan/_events.py
@@ -28,7 +28,7 @@ else:
 class DataContainer:
     _container_dict: dict[str, Any] = {}
 
-    def add(self, value: Any) -> str:
+    def add(self, value: object) -> str:
         key = str(id(value))
         self._container_dict[key] = value
         return key
@@ -561,7 +561,7 @@ class EventMixin:
     def unbind(self, sequence: str) -> None:
         self._bind(sequence, "", True, False)
 
-    def generate_event(self, sequence: str, data: Any = None) -> None:
+    def generate_event(self, sequence: str, data: object = None) -> None:
         global _virtual_event_data_container
         key = _virtual_event_data_container.add(data) if data is not None else None
 

--- a/tukaan/_images.py
+++ b/tukaan/_images.py
@@ -7,7 +7,7 @@ from typing import Union
 from PIL import Image as PIL_Image  # type: ignore
 
 from ._base import WidgetBase
-from ._props import CommandDesc
+from ._props import OptionDesc
 from ._tcl import Tcl
 from ._utils import _images, _pil_images, counts
 from .colors import Color
@@ -197,7 +197,7 @@ class IconFactory:
     __getitem__ = get
 
 
-class ImageProp(CommandDesc[Pillow2Tcl, Union[PillowImage.Image, Icon]]):
+class ImageProp(OptionDesc[Pillow2Tcl, Union[PillowImage.Image, Icon]]):
     def __init__(self):
         super().__init__("image", Pillow2Tcl)
 

--- a/tukaan/_images.py
+++ b/tukaan/_images.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from PIL import Image as PIL_Image  # type: ignore
 
 from ._base import WidgetBase
-from ._props import cget, config
+from ._props import cget, config, WidgetDesc
 from ._tcl import Tcl
 from ._utils import _images, _pil_images, counts
 from .colors import Color
@@ -196,21 +196,15 @@ class IconFactory:
     __getitem__ = get
 
 
-def get_image(self) -> PillowImage.Image | Icon:
-    return cget(self, Pillow2Tcl, "-image")
-
-
-def set_image(self, value: PillowImage.Image | Icon) -> None:
-    config(self, image=value)
-
-
-image = property(get_image, set_image)
+class ImageProp(WidgetDesc[Pillow2Tcl, PillowImage.Image | Icon]):
+    OPTION = "image"
+    TYPE = Pillow2Tcl
 
 
 class Image(WidgetBase):
     _tcl_class = "ttk::label"
 
-    image = image
+    image = ImageProp()
 
     def __init__(self, parent, image: PillowImage.Image | None = None):
         WidgetBase.__init__(self, parent, image=image)

--- a/tukaan/_images.py
+++ b/tukaan/_images.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import contextlib
+from typing import Union
 from pathlib import Path
 
 from PIL import Image as PIL_Image  # type: ignore
 
 from ._base import WidgetBase
-from ._props import cget, config, CommandDesc
+from ._props import CommandDesc
 from ._tcl import Tcl
 from ._utils import _images, _pil_images, counts
 from .colors import Color
@@ -196,9 +197,9 @@ class IconFactory:
     __getitem__ = get
 
 
-class ImageProp(CommandDesc[Pillow2Tcl, PillowImage.Image | Icon]):
-    OPTION = "image"
-    TYPE = Pillow2Tcl
+class ImageProp(CommandDesc[Pillow2Tcl, Union[PillowImage.Image, Icon]]):
+    def __init__(self):
+        super().__init__("image", Pillow2Tcl)
 
 
 class Image(WidgetBase):

--- a/tukaan/_images.py
+++ b/tukaan/_images.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from PIL import Image as PIL_Image  # type: ignore
 
 from ._base import WidgetBase
-from ._props import cget, config, WidgetDesc
+from ._props import cget, config, CommandDesc
 from ._tcl import Tcl
 from ._utils import _images, _pil_images, counts
 from .colors import Color
@@ -196,7 +196,7 @@ class IconFactory:
     __getitem__ = get
 
 
-class ImageProp(WidgetDesc[Pillow2Tcl, PillowImage.Image | Icon]):
+class ImageProp(CommandDesc[Pillow2Tcl, PillowImage.Image | Icon]):
     OPTION = "image"
     TYPE = Pillow2Tcl
 

--- a/tukaan/_images.py
+++ b/tukaan/_images.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import Union
 from pathlib import Path
+from typing import Union
 
 from PIL import Image as PIL_Image  # type: ignore
 

--- a/tukaan/_layout.py
+++ b/tukaan/_layout.py
@@ -142,7 +142,10 @@ class Grid(LayoutManager):
 
         return None, None
 
-    def _get_pad(self):
+    # Properties #
+    
+    @property
+    def padding(self):
         result = Tcl.call(
             {
                 "-padx": (int,),
@@ -154,8 +157,6 @@ class Grid(LayoutManager):
         )
 
         return result["-padx"], result["-pady"]
-
-    # Properties #
 
     @property
     def location(self) -> tuple[int | None, int | None]:
@@ -211,7 +212,7 @@ class Grid(LayoutManager):
 
     @property
     def margin(self) -> tuple[int, ...]:
-        margin = [item if len(item) == 2 else item * 2 for item in self._get_pad()]
+        margin = [item if len(item) == 2 else item * 2 for item in self.padding]
         return margin[1][0], margin[0][1], margin[1][1], margin[0][0]
 
     @margin.setter

--- a/tukaan/_layout.py
+++ b/tukaan/_layout.py
@@ -142,10 +142,7 @@ class Grid(LayoutManager):
 
         return None, None
 
-    # Properties #
-    
-    @property
-    def padding(self):
+    def _get_pad(self):
         result = Tcl.call(
             {
                 "-padx": (int,),
@@ -212,8 +209,8 @@ class Grid(LayoutManager):
 
     @property
     def margin(self) -> tuple[int, ...]:
-        margin = [item if len(item) == 2 else item * 2 for item in self.padding]
-        return margin[1][0], margin[0][1], margin[1][1], margin[0][0]
+        (left, right), (top, bottom) = [x if len(x) == 2 else x * 2 for x in self._get_pad()]
+        return top, right, bottom, left
 
     @margin.setter
     def margin(self, value: tuple[int, ...]) -> None:

--- a/tukaan/_props.py
+++ b/tukaan/_props.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Union, Optional
 
 if sys.version_info >= (3, 9):
+    from collections.abc import Callable
     from typing import Protocol
 else:
+    from typing import Callable
     from typing_extensions import Protocol
 
-from ._base import T_co, T_contra, T
 from ._structures import TabStop
 from ._tcl import Tcl
-from ._utils import _commands, seq_pairs
+from ._utils import _commands, seq_pairs, T_co, T_contra, T
 from ._variables import ControlVariable
 from .colors import Color
 from .enums import ImagePosition, Justify, Orientation
 
 if TYPE_CHECKING:
     from ._base import TkWidget
-    from tukaan.fonts.font import Font
 
 
 def config(widget: TkWidget, **kwargs) -> None:
@@ -71,12 +71,12 @@ class TextAlignProp(CommandDesc[Justify, Justify]):
         super().__init__("justify", Justify)
 
 
-class ForegroundProp(CommandDesc[Color, Color | str]):
+class ForegroundProp(CommandDesc[Color, Union[Color, str]]):
     def __init__(self):
         super().__init__("foreground", Color)
 
 
-class BackgroundProp(CommandDesc[Color, Color | str]):
+class BackgroundProp(CommandDesc[Color, Union[Color, str]]):
     def __init__(self):
         super().__init__("background", Color)
 
@@ -96,7 +96,7 @@ class HeightProp(CommandDesc[int, int]):
         super().__init__("height", int)
 
 
-class CommandProp(CommandDesc[Callable | None, Callable | None]):
+class CommandProp(CommandDesc[Optional[Callable], Optional[Callable]]):
     def __init__(self):
         super().__init__("command", str)
     
@@ -119,15 +119,7 @@ class Value(CommandDesc[int, int]):
         super().__init__("value", int)
 
 
-FontType = Font | dict[str, str | int | bool]
-
-
-class FontProp(CommandDesc[Font, FontType]):
-    def __init__(self):
-        super().__init__("font", Font)
-
-
-class LinkProp(RWProperty[ControlVariable, ControlVariable | None]):
+class LinkProp(RWProperty[ControlVariable, Optional[ControlVariable]]):
     def __get__(self, instance: TkWidget, owner: object = None):
         if owner is None:
             return NotImplemented
@@ -143,7 +135,7 @@ class FocusableProp(CommandDesc[bool, bool]):
         super().__init__("takefocus", bool)
 
 
-class TabStopsProp(RWProperty[list[TabStop], TabStop | list[TabStop]]):
+class TabStopsProp(RWProperty[list[TabStop], Union[TabStop, list[TabStop]]]):
     def __get__(self, instance: TkWidget, owner: object = None):
         if owner is None:
             return NotImplemented
@@ -177,8 +169,8 @@ def _convert_padding(padding: int | tuple[int, ...] | None) -> tuple[int, ...] |
             return (padding[1], padding[0], padding[1], padding[2])
         elif length == 4:
             return (padding[3], padding[0], padding[1], padding[2])
-        else:
-            return ""
+
+        return ""
 
 
 def _convert_padding_back(padding: tuple[int, ...]) -> PaddingType:
@@ -190,11 +182,11 @@ def _convert_padding_back(padding: tuple[int, ...]) -> PaddingType:
     return (0,) * 4
 
 
-class PaddingProp(RWProperty[PaddingType, int | tuple[int, ...] | None]):
+class PaddingProp(RWProperty[PaddingType, Union[int, tuple[int, ...], None]]):
     def __get__(self, instance: TkWidget, owner: object = None):
         if owner is None:
             return NotImplemented
-        return _convert_padding_back(cget(instance, tuple[int, ...], "-padding"))
+        return _convert_padding_back(cget(instance, (int,), "-padding"))
 
     def __set__(self, instance: TkWidget, value: int | tuple[int, ...] | None):
         config(instance, padding=_convert_padding(value))

--- a/tukaan/_props.py
+++ b/tukaan/_props.py
@@ -37,66 +37,71 @@ class RWProperty(Protocol[T_co, T_contra]):
         ...
 
 
-class CommandDesc(RWProperty[T, T_contra]):
-    def __init__(self, command: str, type: type[T]):
-        self._command = command
-        self._type = type
+class OptionDesc(RWProperty[T, T_contra]):
+    def __init__(self, option: str, type_: type[T]):
+        self._option = option
+        self._type = type_
 
     def __get__(self, instance: TkWidget, owner: object = None) -> T:
         if owner is None:
             return NotImplemented
-        return cget(instance, self._type, f"-{self._command}")
+        return cget(instance, self._type, f"-{self._option}")
 
     def __set__(self, instance: TkWidget, value: T_contra):
-        config(instance, **{self._command: value})
+        config(instance, **{self._option: value})
 
 
-class BoolDesc(CommandDesc[bool, bool]):
-    def __init__(self, command: str):
-        super().__init__(command, bool)
+class BoolDesc(OptionDesc[bool, bool]):
+    def __init__(self, option: str):
+        super().__init__(option, bool)
 
 
-class FloatDesc(CommandDesc[float, float]):
-    def __init__(self, command: str):
-        super().__init__(command, float)
+class IntDesc(OptionDesc[int, int]):
+    def __init__(self, option: str):
+        super().__init__(option, int)
 
 
-class ImagePositionProp(CommandDesc[ImagePosition, ImagePosition]):
+class FloatDesc(OptionDesc[float, float]):
+    def __init__(self, option: str):
+        super().__init__(option, float)
+
+
+class ImagePositionProp(OptionDesc[ImagePosition, ImagePosition]):
     def __init__(self):
         super().__init__("compound", ImagePosition)
 
 
-class TextAlignProp(CommandDesc[Justify, Justify]):
+class TextAlignProp(OptionDesc[Justify, Justify]):
     def __init__(self):
         super().__init__("justify", Justify)
 
 
-class ForegroundProp(CommandDesc[Color, Union[Color, str]]):
+class ForegroundProp(OptionDesc[Color, Union[Color, str]]):
     def __init__(self):
         super().__init__("foreground", Color)
 
 
-class BackgroundProp(CommandDesc[Color, Union[Color, str]]):
+class BackgroundProp(OptionDesc[Color, Union[Color, str]]):
     def __init__(self):
         super().__init__("background", Color)
 
 
-class TextProp(CommandDesc[str, str]):
+class TextProp(OptionDesc[str, str]):
     def __init__(self):
         super().__init__("text", str)
 
 
-class WidthProp(CommandDesc[int, int]):
+class WidthProp(OptionDesc[int, int]):
     def __init__(self):
         super().__init__("width", int)
 
 
-class HeightProp(CommandDesc[int, int]):
+class HeightProp(OptionDesc[int, int]):
     def __init__(self):
         super().__init__("height", int)
 
 
-class CommandProp(CommandDesc[Optional[Callable], Optional[Callable]]):
+class CommandProp(OptionDesc[Optional[Callable], Optional[Callable]]):
     def __init__(self):
         super().__init__("command", str)
 
@@ -109,14 +114,9 @@ class CommandProp(CommandDesc[Optional[Callable], Optional[Callable]]):
         super().__set__(instance, value or "")
 
 
-class OrientProp(CommandDesc[Orientation, Orientation]):
+class OrientProp(OptionDesc[Orientation, Orientation]):
     def __init__(self):
         super().__init__("orient", Orientation)
-
-
-class Value(CommandDesc[int, int]):
-    def __init__(self):
-        super().__init__("value", int)
 
 
 class LinkProp(RWProperty[ControlVariable, Optional[ControlVariable]]):
@@ -130,7 +130,7 @@ class LinkProp(RWProperty[ControlVariable, Optional[ControlVariable]]):
         return config(instance, variable=value or "")
 
 
-class FocusableProp(CommandDesc[bool, bool]):
+class FocusableProp(OptionDesc[bool, bool]):
     def __init__(self):
         super().__init__("takefocus", bool)
 

--- a/tukaan/_props.py
+++ b/tukaan/_props.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Union, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 if sys.version_info >= (3, 9):
     from collections.abc import Callable
@@ -12,7 +12,7 @@ else:
 
 from ._structures import TabStop
 from ._tcl import Tcl
-from ._utils import _commands, seq_pairs, T_co, T_contra, T
+from ._utils import T, T_co, T_contra, _commands, seq_pairs
 from ._variables import ControlVariable
 from .colors import Color
 from .enums import ImagePosition, Justify, Orientation
@@ -99,7 +99,7 @@ class HeightProp(CommandDesc[int, int]):
 class CommandProp(CommandDesc[Optional[Callable], Optional[Callable]]):
     def __init__(self):
         super().__init__("command", str)
-    
+
     def __get__(self, instance: TkWidget, owner: object = None):
         if owner is None:
             return NotImplemented

--- a/tukaan/_tcl.py
+++ b/tukaan/_tcl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+import functools
 import sys
 import traceback
 from enum import Enum, EnumMeta
@@ -112,7 +113,7 @@ class Tcl:
             return Path(value).resolve()
 
     @staticmethod
-    def to(value: Any) -> str | tuple | tk.Tcl_Obj:
+    def to(value: object) -> str | tuple | tk.Tcl_Obj:
         if isinstance(value, (str, tk.Tcl_Obj)):
             return value
 
@@ -151,7 +152,7 @@ class Tcl:
             ) from None
 
     @staticmethod
-    def call(return_type: Any, *args) -> Any:
+    def call(return_type: object, *args) -> Any:
         try:
             result = _tcl_interp.call(*map(Tcl.to, args))
             if return_type is None:
@@ -173,7 +174,7 @@ class Tcl:
             raise FileNotFoundError(f"No such file or directory: {path!r}") from None
 
     @staticmethod
-    def eval(return_type: Any, script: str) -> Any:
+    def eval(return_type: object, script: str) -> Any:
         try:
             result = _tcl_interp.eval(script)
         except tk.TclError as e:
@@ -245,6 +246,7 @@ class Tcl:
 
     @staticmethod
     def updated(func: Callable) -> Callable:
+        @functools.wraps(func)
         def wrapper(self, *args, **kwargs) -> Any:
             _tcl_interp.eval("update idletasks")
             result = func(self, *args, **kwargs)
@@ -255,6 +257,7 @@ class Tcl:
 
     @staticmethod
     def update_before(func: Callable) -> Callable:
+        @functools.wraps(func)
         def wrapper(self, *args, **kwargs) -> Any:
             _tcl_interp.eval("update idletasks")
             return func(self, *args, **kwargs)
@@ -263,6 +266,7 @@ class Tcl:
 
     @staticmethod
     def update_after(func: Callable) -> Callable:
+        @functools.wraps(func)
         def wrapper(self, *args, **kwargs) -> Any:
             result = func(self, *args, **kwargs)
             _tcl_interp.eval("update idletasks")

--- a/tukaan/_utils.py
+++ b/tukaan/_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import collections.abc
 import itertools
-from typing import TYPE_CHECKING, Any, Callable, DefaultDict, Iterator
+from typing import TYPE_CHECKING, Any, Callable, DefaultDict, Iterator, TypeVar
 
 if TYPE_CHECKING:
     from PIL import Image  # type: ignore
@@ -15,8 +15,13 @@ if TYPE_CHECKING:
     from .timeouts import Timeout
 
 
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+
+
 class count:
-    """Simplified itertools.count"""
+    """Simplified itertools.count."""
 
     def __init__(self, start: int = 0) -> None:
         self._count = start

--- a/tukaan/_wm.py
+++ b/tukaan/_wm.py
@@ -73,7 +73,6 @@ class WMProperties:
     def y(self, value: int) -> None:
         Tcl.call(None, "wm", "geometry", self._wm_path, f"+{self.x}+{value}")
 
-
     @property
     @Tcl.update_before
     def width(self) -> int:
@@ -111,7 +110,6 @@ class WMProperties:
             value = (value,) * 2
 
         Tcl.call(None, "wm", "geometry", self._wm_path, "{}x{}".format(*value))
-
 
 
 class WindowManagerBase(ABC, WMProperties):

--- a/tukaan/app.py
+++ b/tukaan/app.py
@@ -35,8 +35,8 @@ class App(WindowBase):
         Tcl.call(None, "bind", self, "<Configure>", self._generate_state_event)
         Tcl.call(None, "wm", "protocol", self._wm_path, "WM_DELETE_WINDOW", self.destroy)
 
-        self._set_title(title)
-        self._set_size((width, height))
+        self.title = title
+        self.size = (width, height)
 
         self._init_tkdnd()
         Serif.init()

--- a/tukaan/fonts/font.py
+++ b/tukaan/fonts/font.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from collections.abc import Iterator
 from pathlib import Path
 
 from libtukaan import Serif
 
 from tukaan._base import TkWidget
-from tukaan._props import RWProperty, T_co, T_contra
+from tukaan._props import RWProperty, T_co
 from tukaan._tcl import Tcl
 from tukaan._utils import _fonts, counts, seq_pairs
 from tukaan.exceptions import FontError, TclError
 
-from .fontfile import FontFile, TrueTypeCollection
+from .fontfile import FontFile, FontInfo, TrueTypeCollection
 
 preset_fonts = {
     "TkCaptionFont",

--- a/tukaan/fonts/font.py
+++ b/tukaan/fonts/font.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from tukaan._base import TkWidget
 
-from tukaan._props import CommandDesc, RWProperty, T_co
+from tukaan._props import OptionDesc, RWProperty, T_co
 from tukaan._tcl import Tcl
 from tukaan._utils import _fonts, counts, seq_pairs
 from tukaan.exceptions import FontError, TclError
@@ -283,6 +283,6 @@ def font(
 FontType = Union[Font, dict[str, Union[str, int, bool]]]
 
 
-class FontProp(CommandDesc[Font, FontType]):
+class FontProp(OptionDesc[Font, FontType]):
     def __init__(self):
         super().__init__("font", Font)

--- a/tukaan/fonts/font.py
+++ b/tukaan/fonts/font.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from libtukaan import Serif
 
+from tukaan._base import TkWidget
+from tukaan._props import RWProperty, T_co, T_contra
 from tukaan._tcl import Tcl
 from tukaan._utils import _fonts, counts, seq_pairs
 from tukaan.exceptions import FontError, TclError
@@ -28,6 +30,52 @@ preset_fonts = {
 FontMetrics = namedtuple("FontMetrics", ["ascent", "descent", "line_spacing", "fixed"])
 
 
+class _FontProperty(RWProperty[T_co, T_co]):
+    TYPE: type[str] | type[int] | type[bool]
+
+    def __init__(self, option: str | None = None) -> None:
+        self._option = option
+
+    def __set_name__(self, owner: object, name: str):
+        if self._option is None:
+            self._option = name
+
+    def __get__(self, instance: TkWidget, owner: object = None) -> T_co:
+        if owner is None:
+            return NotImplemented
+        return Tcl.call(self.TYPE, "font", "actual", instance, f"-{self._option}")
+
+    def __set__(self, instance: TkWidget, value: object):
+        Tcl.call(None, "font", "configure", instance._name, f"-{self._option}", value)
+
+
+class _BoolFontProperty(_FontProperty[bool]):
+    TYPE = bool
+
+
+class _IntFontProperty(_FontProperty[int]):
+    TYPE = int
+
+
+class _StrFontProperty(_FontProperty[str]):
+    TYPE = str
+
+
+class _FontStyleProperty(_FontProperty[bool]):
+    TYPE = str
+    
+    def __init__(self, option: str, truthy: str, falsy: str) -> None:
+        self._option = option
+        self._truthy = truthy
+        self._falsy = falsy
+
+    def __get__(self, instance: TkWidget, owner: object = None):
+        return super().__get__(instance, owner) == self._truthy
+
+    def __set__(self, instance: TkWidget, value: object):
+        return super().__set__(instance, self._truthy if value else self._falsy)
+
+
 class Font:
     """
     A mutable font object, that can be linked to a Tukaan widget.
@@ -44,7 +92,7 @@ class Font:
     def __init__(
         self,
         family: FontFile | str | None = None,
-        size: int = None,
+        size: int | None = None,
         bold: bool = False,
         italic: bool = False,
         underline: bool = False,
@@ -91,7 +139,7 @@ class Font:
     def config(
         self,
         family: str | None = None,
-        size: int = None,
+        size: int | None = None,
         bold: bool = False,
         italic: bool = False,
         underline: bool = False,
@@ -150,65 +198,23 @@ class Font:
 
             return kwargs
 
-    def _get(self, type_spec: type[int] | type[str] | type[bool], option: str) -> int | str | bool:
-        return Tcl.call(type_spec, "font", "actual", self, f"-{option}")
+    family = _StrFontProperty()
+    """Get or set the current font family."""
 
-    def _set(self, option: str, value: int | str | bool) -> None:
-        Tcl.call(None, "font", "configure", self._name, f"-{option}", value)
+    size = _IntFontProperty()
+    """Get or set the current font size."""
 
-    @property
-    def family(self) -> str:
-        """Get or set the current font family."""
-        return self._get(str, "family")
+    bold = _FontStyleProperty("weight", "bold", "normal")
+    """Get or set whether the font should be drawn as bold."""
 
-    @family.setter
-    def family(self, value: str) -> None:
-        self._set("family", value)
+    italic = _FontStyleProperty("slant", "italic", "roman")
+    """Get or set whether the font should be drawn as italic."""
 
-    @property
-    def size(self) -> int:
-        """Get or set the current font size."""
-        return self._get(int, "size")
+    underline = _BoolFontProperty()
+    """Get or set whether the font should have underlining."""
 
-    @size.setter
-    def size(self, value: int):
-        self._set("size", value)
-
-    @property
-    def bold(self) -> bool:
-        """Get or set whether the font should be drawn as bold."""
-        return self._get(str, "weight") == "bold"
-
-    @bold.setter
-    def bold(self, value: bool) -> None:
-        self._set("weight", "bold" if value else "normal")
-
-    @property
-    def italic(self) -> bool:
-        """Get or set whether the font should be drawn as italic."""
-        return self._get(str, "slant") == "italic"
-
-    @italic.setter
-    def italic(self, value: bool) -> None:
-        self._set("slant", "italic" if value else "roman")
-
-    @property
-    def underline(self) -> bool:
-        """Get or set whether the font should have underlining."""
-        return self._get(bool, "underline")
-
-    @underline.setter
-    def underline(self, value: bool) -> None:
-        self._set("underline", value)
-
-    @property
-    def strikethrough(self) -> bool:
-        """Get or set whether the font should be striked through."""
-        return self._get(bool, "overstrike")
-
-    @strikethrough.setter
-    def strikethrough(self, value: bool) -> None:
-        self._set("overstrike", value)
+    strikethrough = _BoolFontProperty("overstrike")
+    """Get or set whether the font should be striked through."""
 
     def dispose(self) -> None:
         """

--- a/tukaan/fonts/font.py
+++ b/tukaan/fonts/font.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import TYPE_CHECKING, Union
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from pathlib import Path
     from tukaan._base import TkWidget
 
-from tukaan._props import RWProperty, T_co, CommandDesc
+from tukaan._props import CommandDesc, RWProperty, T_co
 from tukaan._tcl import Tcl
 from tukaan._utils import _fonts, counts, seq_pairs
 from tukaan.exceptions import FontError, TclError

--- a/tukaan/screen_distance.py
+++ b/tukaan/screen_distance.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ._info import Screen
-from .exceptions import ColorError
 
 
 def mm(amount):

--- a/tukaan/timeouts.py
+++ b/tukaan/timeouts.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from ._tcl import Tcl
 

--- a/tukaan/widgets/button.py
+++ b/tukaan/widgets/button.py
@@ -6,7 +6,7 @@ from PIL import Image  # type: ignore
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
 from tukaan._images import Icon
-from tukaan._props import Command, TakeFocus, Compound, Text, Width
+from tukaan._props import CommandProp, FocusableProp, ImagePositionProp, TextProp, WidthProp
 from tukaan._tcl import Tcl
 from tukaan.enums import ImagePosition
 
@@ -14,11 +14,11 @@ from tukaan.enums import ImagePosition
 class Button(WidgetBase, InputControl):
     _tcl_class = "ttk::button"
 
-    focusable = TakeFocus()
-    image_pos = Compound()
-    on_click = Command()
-    text = Text()
-    width = Width()
+    focusable = FocusableProp()
+    image_pos = ImagePositionProp()
+    on_click = CommandProp()
+    text = TextProp()
+    width = WidthProp()
 
     def __init__(
         self,

--- a/tukaan/widgets/button.py
+++ b/tukaan/widgets/button.py
@@ -6,7 +6,7 @@ from PIL import Image  # type: ignore
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
 from tukaan._images import Icon
-from tukaan._props import command, focusable, image_pos, text, width
+from tukaan._props import Command, TakeFocus, Compound, Text, Width
 from tukaan._tcl import Tcl
 from tukaan.enums import ImagePosition
 
@@ -14,11 +14,11 @@ from tukaan.enums import ImagePosition
 class Button(WidgetBase, InputControl):
     _tcl_class = "ttk::button"
 
-    focusable = focusable
-    image_pos = image_pos
-    on_click = command
-    text = text
-    width = width
+    focusable = TakeFocus()
+    image_pos = Compound()
+    on_click = Command()
+    text = Text()
+    width = Width()
 
     def __init__(
         self,

--- a/tukaan/widgets/checkbox.py
+++ b/tukaan/widgets/checkbox.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import config, FocusableProp, LinkProp, TextProp, WidthProp
+from tukaan._props import FocusableProp, LinkProp, TextProp, WidthProp, config
 from tukaan._tcl import Tcl
 from tukaan._variables import Boolean
 

--- a/tukaan/widgets/checkbox.py
+++ b/tukaan/widgets/checkbox.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import config, focusable, link, text, width
+from tukaan._props import config, TakeFocus, Link, Text, Width
 from tukaan._tcl import Tcl
 from tukaan._variables import Boolean
 
@@ -13,10 +13,10 @@ class CheckBox(WidgetBase, InputControl):
 
     _variable: Boolean
 
-    focusable = focusable
-    link = link
-    text = text
-    width = width
+    focusable = TakeFocus()
+    link = Link()
+    text = Text()
+    width = Width()
 
     def __init__(
         self,

--- a/tukaan/widgets/checkbox.py
+++ b/tukaan/widgets/checkbox.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import config, TakeFocus, Link, Text, Width
+from tukaan._props import config, FocusableProp, LinkProp, TextProp, WidthProp
 from tukaan._tcl import Tcl
 from tukaan._variables import Boolean
 
@@ -13,10 +13,10 @@ class CheckBox(WidgetBase, InputControl):
 
     _variable: Boolean
 
-    focusable = TakeFocus()
-    link = Link()
-    text = Text()
-    width = Width()
+    focusable = FocusableProp()
+    link = LinkProp()
+    text = TextProp()
+    width = WidthProp()
 
     def __init__(
         self,

--- a/tukaan/widgets/frame.py
+++ b/tukaan/widgets/frame.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from tukaan._base import Container, TkWidget, WidgetBase
-from tukaan._props import padding, set_padding
+from tukaan._props import Padding
 
 
 class Frame(WidgetBase, Container):
     _tcl_class = "ttk::frame"
 
-    padding = padding
+    padding = Padding()
 
     def __init__(
         self,
@@ -17,4 +17,4 @@ class Frame(WidgetBase, Container):
     ) -> None:
         WidgetBase.__init__(self, parent, tooltip=tooltip)
 
-        set_padding(self, padding)
+        self.padding = padding

--- a/tukaan/widgets/frame.py
+++ b/tukaan/widgets/frame.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from tukaan._base import Container, TkWidget, WidgetBase
-from tukaan._props import Padding
+from tukaan._props import PaddingProp
 
 
 class Frame(WidgetBase, Container):
     _tcl_class = "ttk::frame"
 
-    padding = Padding()
+    padding = PaddingProp()
 
     def __init__(
         self,

--- a/tukaan/widgets/label.py
+++ b/tukaan/widgets/label.py
@@ -4,7 +4,8 @@ from PIL import Image  # type: ignore
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
 from tukaan._images import Icon, ImageProp
-from tukaan._props import BackgroundProp, cget, config, FocusableProp, FontProp, ImagePositionProp, TextProp, TextAlignProp
+from tukaan._props import BackgroundProp, cget, config, FocusableProp, ImagePositionProp, TextProp, TextAlignProp
+from tukaan.fonts.font import FontProp
 from tukaan.colors import Color
 from tukaan.enums import Anchor, ImagePosition, Justify
 from tukaan.fonts.font import Font

--- a/tukaan/widgets/label.py
+++ b/tukaan/widgets/label.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from PIL import Image  # type: ignore
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
-from tukaan._images import Icon, image
-from tukaan._props import bg_color, cget, config, focusable, font, image_pos, text, text_align
+from tukaan._images import Icon, ImageProp
+from tukaan._props import Background, cget, config, TakeFocus, FontProp, Compound, Text, TextAlign
 from tukaan.colors import Color
 from tukaan.enums import Anchor, ImagePosition, Justify
 from tukaan.fonts.font import Font
@@ -13,13 +13,13 @@ from tukaan.fonts.font import Font
 class Label(WidgetBase, OutputDisplay):
     _tcl_class = "ttk::label"
 
-    bg_color = bg_color
-    focusable = focusable
-    font = font
-    image = image
-    image_pos = image_pos
-    text = text
-    text_align = text_align
+    bg_color = Background()
+    focusable = TakeFocus()
+    font = FontProp()
+    image = ImageProp()
+    image_pos = Compound()
+    text = Text()
+    text_align = TextAlign()
 
     def __init__(
         self,

--- a/tukaan/widgets/label.py
+++ b/tukaan/widgets/label.py
@@ -4,11 +4,18 @@ from PIL import Image  # type: ignore
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
 from tukaan._images import Icon, ImageProp
-from tukaan._props import BackgroundProp, cget, config, FocusableProp, ImagePositionProp, TextProp, TextAlignProp
-from tukaan.fonts.font import FontProp
+from tukaan._props import (
+    BackgroundProp,
+    FocusableProp,
+    ImagePositionProp,
+    TextAlignProp,
+    TextProp,
+    cget,
+    config,
+)
 from tukaan.colors import Color
 from tukaan.enums import Anchor, ImagePosition, Justify
-from tukaan.fonts.font import Font
+from tukaan.fonts.font import Font, FontProp
 
 
 class Label(WidgetBase, OutputDisplay):

--- a/tukaan/widgets/label.py
+++ b/tukaan/widgets/label.py
@@ -4,7 +4,7 @@ from PIL import Image  # type: ignore
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
 from tukaan._images import Icon, ImageProp
-from tukaan._props import Background, cget, config, TakeFocus, FontProp, Compound, Text, TextAlign
+from tukaan._props import BackgroundProp, cget, config, FocusableProp, FontProp, ImagePositionProp, TextProp, TextAlignProp
 from tukaan.colors import Color
 from tukaan.enums import Anchor, ImagePosition, Justify
 from tukaan.fonts.font import Font
@@ -13,13 +13,13 @@ from tukaan.fonts.font import Font
 class Label(WidgetBase, OutputDisplay):
     _tcl_class = "ttk::label"
 
-    bg_color = Background()
-    focusable = TakeFocus()
+    bg_color = BackgroundProp()
+    focusable = FocusableProp()
     font = FontProp()
     image = ImageProp()
-    image_pos = Compound()
-    text = Text()
-    text_align = TextAlign()
+    image_pos = ImagePositionProp()
+    text = TextProp()
+    text_align = TextAlignProp()
 
     def __init__(
         self,

--- a/tukaan/widgets/progressbar.py
+++ b/tukaan/widgets/progressbar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Generator
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
-from tukaan._props import cget, config, focusable, link, orientation, value
+from tukaan._props import cget, config, TakeFocus, Link, Orient, Value
 from tukaan._tcl import Tcl
 from tukaan._variables import Float, Integer
 from tukaan.enums import Orientation, ProgressMode
@@ -13,10 +13,10 @@ from tukaan.timeouts import Timeout
 class ProgressBar(WidgetBase, OutputDisplay):
     _tcl_class = "ttk::progressbar"
 
-    focusable = focusable
-    orientation = orientation
-    value = value
-    link = link
+    focusable = TakeFocus()
+    orientation = Orient()
+    value = Value()
+    link = Link()
 
     _timeout = None
 
@@ -47,7 +47,7 @@ class ProgressBar(WidgetBase, OutputDisplay):
         )
 
     def _repr_details(self):
-        return f"mode={self.mode!r}, length={self.max!r}, value={self.value!r}"
+        return f"mode={self.mode!r}, length={self._max!r}, value={self.value!r}"
 
     def step(self, amount: int = 1) -> None:
         Tcl.call(None, self, "step", amount)

--- a/tukaan/widgets/progressbar.py
+++ b/tukaan/widgets/progressbar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Generator
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
-from tukaan._props import FocusableProp, LinkProp, OrientProp, Value, cget, config
+from tukaan._props import FocusableProp, LinkProp, OrientProp, IntDesc, cget, config
 from tukaan._tcl import Tcl
 from tukaan._variables import Float, Integer
 from tukaan.enums import Orientation, ProgressMode
@@ -15,7 +15,7 @@ class ProgressBar(WidgetBase, OutputDisplay):
 
     focusable = FocusableProp()
     orientation = OrientProp()
-    value = Value()
+    value = IntDesc("value")
     link = LinkProp()
 
     _timeout = None

--- a/tukaan/widgets/progressbar.py
+++ b/tukaan/widgets/progressbar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Generator
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
-from tukaan._props import FocusableProp, LinkProp, OrientProp, IntDesc, cget, config
+from tukaan._props import FocusableProp, IntDesc, LinkProp, OrientProp, cget, config
 from tukaan._tcl import Tcl
 from tukaan._variables import Float, Integer
 from tukaan.enums import Orientation, ProgressMode

--- a/tukaan/widgets/progressbar.py
+++ b/tukaan/widgets/progressbar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Generator
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
-from tukaan._props import cget, config, TakeFocus, Link, Orient, Value
+from tukaan._props import cget, config, FocusableProp, LinkProp, OrientProp, Value
 from tukaan._tcl import Tcl
 from tukaan._variables import Float, Integer
 from tukaan.enums import Orientation, ProgressMode
@@ -13,10 +13,10 @@ from tukaan.timeouts import Timeout
 class ProgressBar(WidgetBase, OutputDisplay):
     _tcl_class = "ttk::progressbar"
 
-    focusable = TakeFocus()
-    orientation = Orient()
+    focusable = FocusableProp()
+    orientation = OrientProp()
     value = Value()
-    link = Link()
+    link = LinkProp()
 
     _timeout = None
 

--- a/tukaan/widgets/progressbar.py
+++ b/tukaan/widgets/progressbar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Generator
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
-from tukaan._props import cget, config, FocusableProp, LinkProp, OrientProp, Value
+from tukaan._props import FocusableProp, LinkProp, OrientProp, Value, cget, config
 from tukaan._tcl import Tcl
 from tukaan._variables import Float, Integer
 from tukaan.enums import Orientation, ProgressMode

--- a/tukaan/widgets/radiobutton.py
+++ b/tukaan/widgets/radiobutton.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import command, focusable, link, text, value, width
+from tukaan._props import Command, TakeFocus, Link, Text, Value, Width
 from tukaan._tcl import Tcl
 from tukaan._variables import ControlVariable, String
 from tukaan.enums import Orientation
@@ -14,12 +14,12 @@ from .frame import Frame
 class RadioButton(WidgetBase, InputControl):
     _tcl_class = "ttk::radiobutton"
 
-    focusable = focusable
-    link = link
-    on_click = command
-    text = text
-    value = value
-    width = width
+    focusable = TakeFocus()
+    link = Link()
+    on_click = Command()
+    text = Text()
+    value = Value()
+    width = Width()
 
     def __init__(
         self,

--- a/tukaan/widgets/radiobutton.py
+++ b/tukaan/widgets/radiobutton.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import CommandProp, FocusableProp, LinkProp, TextProp, Value, WidthProp
+from tukaan._props import CommandProp, FocusableProp, LinkProp, TextProp, IntDesc, WidthProp, cget, config
 from tukaan._tcl import Tcl
 from tukaan._variables import ControlVariable, String
 from tukaan.enums import Orientation
@@ -18,7 +18,6 @@ class RadioButton(WidgetBase, InputControl):
     link = LinkProp()
     on_click = CommandProp()
     text = TextProp()
-    value = Value()
     width = WidthProp()
 
     def __init__(
@@ -34,6 +33,7 @@ class RadioButton(WidgetBase, InputControl):
         width: int | None = None,
     ) -> None:
         self._variable = link
+        self._value_type = type(value)
 
         WidgetBase.__init__(
             self,
@@ -48,20 +48,28 @@ class RadioButton(WidgetBase, InputControl):
         )
 
     def invoke(self):
-        """Invokes the radiobutton, as if it were clicked"""
-
+        """Invoke the radiobutton, as if it were clicked."""
         Tcl.call(None, self, "invoke")
 
     def select(self):
-        """Selects the radiobutton"""
-
+        """Select the radiobutton."""
         self._variable.set(self.value)
 
     @property
     def selected(self) -> bool:
-        """Returns if the radiobutton is selected or not"""
-
+        """Return whether the radiobutton is selected or not."""
         return self._variable.get() == self.value
+
+    ### Properties ###
+
+    @property
+    def value(self) -> str | float | bool:
+        return cget(self, self._value_type, "-value")
+
+    @value.setter
+    def value(self, value: str | float | bool) -> None:
+        self._value_type = type(value)
+        config(self, value=value)
 
 
 class RadioGroup(Frame, InputControl):

--- a/tukaan/widgets/radiobutton.py
+++ b/tukaan/widgets/radiobutton.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import Command, TakeFocus, Link, Text, Value, Width
+from tukaan._props import CommandProp, FocusableProp, LinkProp, TextProp, Value, WidthProp
 from tukaan._tcl import Tcl
 from tukaan._variables import ControlVariable, String
 from tukaan.enums import Orientation
@@ -14,12 +14,12 @@ from .frame import Frame
 class RadioButton(WidgetBase, InputControl):
     _tcl_class = "ttk::radiobutton"
 
-    focusable = TakeFocus()
-    link = Link()
-    on_click = Command()
-    text = Text()
+    focusable = FocusableProp()
+    link = LinkProp()
+    on_click = CommandProp()
+    text = TextProp()
     value = Value()
-    width = Width()
+    width = WidthProp()
 
     def __init__(
         self,

--- a/tukaan/widgets/radiobutton.py
+++ b/tukaan/widgets/radiobutton.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import CommandProp, FocusableProp, LinkProp, TextProp, IntDesc, WidthProp, cget, config
+from tukaan._props import (
+    CommandProp,
+    FocusableProp,
+    IntDesc,
+    LinkProp,
+    TextProp,
+    WidthProp,
+    cget,
+    config,
+)
 from tukaan._tcl import Tcl
 from tukaan._variables import ControlVariable, String
 from tukaan.enums import Orientation

--- a/tukaan/widgets/scrollbar.py
+++ b/tukaan/widgets/scrollbar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import config, FocusableProp, OrientProp
+from tukaan._props import FocusableProp, OrientProp, config
 from tukaan._tcl import Tcl
 from tukaan.enums import Orientation
 from tukaan.exceptions import WidgetError

--- a/tukaan/widgets/scrollbar.py
+++ b/tukaan/widgets/scrollbar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import config, TakeFocus, Orient
+from tukaan._props import config, FocusableProp, OrientProp
 from tukaan._tcl import Tcl
 from tukaan.enums import Orientation
 from tukaan.exceptions import WidgetError
@@ -12,8 +12,8 @@ from tukaan.exceptions import WidgetError
 class ScrollBar(WidgetBase, InputControl):
     _tcl_class = "ttk::scrollbar"
 
-    focusable = TakeFocus()
-    orientation = Orient()
+    focusable = FocusableProp()
+    orientation = OrientProp()
 
     _hidden = False
 

--- a/tukaan/widgets/scrollbar.py
+++ b/tukaan/widgets/scrollbar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import config, focusable, orientation
+from tukaan._props import config, TakeFocus, Orient
 from tukaan._tcl import Tcl
 from tukaan.enums import Orientation
 from tukaan.exceptions import WidgetError
@@ -12,8 +12,8 @@ from tukaan.exceptions import WidgetError
 class ScrollBar(WidgetBase, InputControl):
     _tcl_class = "ttk::scrollbar"
 
-    focusable = focusable
-    orientation = orientation
+    focusable = TakeFocus()
+    orientation = Orient()
 
     _hidden = False
 

--- a/tukaan/widgets/separator.py
+++ b/tukaan/widgets/separator.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
-from tukaan._props import Orient
+from tukaan._props import OrientProp
 from tukaan.enums import Orientation
 
 
 class Separator(WidgetBase, OutputDisplay):
     _tcl_class = "ttk::separator"
 
-    orientation = Orient()
+    orientation = OrientProp()
 
     def __init__(
         self,

--- a/tukaan/widgets/separator.py
+++ b/tukaan/widgets/separator.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from tukaan._base import OutputDisplay, TkWidget, WidgetBase
-from tukaan._props import orientation
+from tukaan._props import Orient
 from tukaan.enums import Orientation
 
 
 class Separator(WidgetBase, OutputDisplay):
     _tcl_class = "ttk::separator"
 
-    orientation = orientation
+    orientation = Orient()
 
     def __init__(
         self,

--- a/tukaan/widgets/slider.py
+++ b/tukaan/widgets/slider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import cget, config, FocusableProp, LinkProp, OrientProp, Value
+from tukaan._props import FocusableProp, LinkProp, OrientProp, Value, cget, config
 from tukaan._variables import Float, Integer
 from tukaan.enums import Orientation
 

--- a/tukaan/widgets/slider.py
+++ b/tukaan/widgets/slider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import cget, config, TakeFocus, Link, Orient, Value
+from tukaan._props import cget, config, FocusableProp, LinkProp, OrientProp, Value
 from tukaan._variables import Float, Integer
 from tukaan.enums import Orientation
 
@@ -11,9 +11,9 @@ from tukaan.enums import Orientation
 class Slider(WidgetBase, InputControl):
     _tcl_class = "ttk::scale"
 
-    focusable = TakeFocus()
-    link = Link()
-    orientation = Orient()
+    focusable = FocusableProp()
+    link = LinkProp()
+    orientation = OrientProp()
     value = Value()
 
     def __init__(

--- a/tukaan/widgets/slider.py
+++ b/tukaan/widgets/slider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import FocusableProp, LinkProp, OrientProp, IntDesc, cget, config
+from tukaan._props import FocusableProp, IntDesc, LinkProp, OrientProp, cget, config
 from tukaan._variables import Float, Integer
 from tukaan.enums import Orientation
 

--- a/tukaan/widgets/slider.py
+++ b/tukaan/widgets/slider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import cget, config, focusable, link, orientation, value
+from tukaan._props import cget, config, TakeFocus, Link, Orient, Value
 from tukaan._variables import Float, Integer
 from tukaan.enums import Orientation
 
@@ -11,10 +11,10 @@ from tukaan.enums import Orientation
 class Slider(WidgetBase, InputControl):
     _tcl_class = "ttk::scale"
 
-    focusable = focusable
-    link = link
-    orientation = orientation
-    value = value
+    focusable = TakeFocus()
+    link = Link()
+    orientation = Orient()
+    value = Value()
 
     def __init__(
         self,

--- a/tukaan/widgets/slider.py
+++ b/tukaan/widgets/slider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase
-from tukaan._props import FocusableProp, LinkProp, OrientProp, Value, cget, config
+from tukaan._props import FocusableProp, LinkProp, OrientProp, IntDesc, cget, config
 from tukaan._variables import Float, Integer
 from tukaan.enums import Orientation
 
@@ -14,7 +14,7 @@ class Slider(WidgetBase, InputControl):
     focusable = FocusableProp()
     link = LinkProp()
     orientation = OrientProp()
-    value = Value()
+    value = IntDesc("value")
 
     def __init__(
         self,

--- a/tukaan/widgets/spinbox.py
+++ b/tukaan/widgets/spinbox.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable, Iterable
 
 from tukaan._base import TkWidget, WidgetBase
-from tukaan._props import cget, config
+from tukaan._props import cget, config, BoolDesc, FloatDesc
 from tukaan._tcl import Tcl
 from tukaan.colors import Color
 
@@ -105,21 +105,8 @@ class SpinBox(TextBox):
     def values(self, values: Iterable[str | float] | range | None) -> None:
         self._set_values(values, None)
 
-    @property
-    def cycle(self) -> bool:
-        return cget(self, bool, "-wrap")
-
-    @cycle.setter
-    def cycle(self, value: bool) -> None:
-        config(self, wrap=value)
-
-    @property
-    def step(self) -> float:
-        return cget(self, float, "-increment")
-
-    @step.setter
-    def step(self, value: float) -> None:
-        config(self, increment=value)
+    cycle = BoolDesc("wrap")
+    step = FloatDesc("increment")
 
     @property
     def on_select(self) -> Callable[[str], None] | None:

--- a/tukaan/widgets/spinbox.py
+++ b/tukaan/widgets/spinbox.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable, Iterable
 
 from tukaan._base import TkWidget, WidgetBase
-from tukaan._props import cget, config, BoolDesc, FloatDesc
+from tukaan._props import BoolDesc, FloatDesc, cget, config
 from tukaan._tcl import Tcl
 from tukaan.colors import Color
 

--- a/tukaan/widgets/splitview.py
+++ b/tukaan/widgets/splitview.py
@@ -4,7 +4,7 @@ import contextlib
 from collections.abc import Iterator
 
 from tukaan._base import Container, TkWidget, WidgetBase
-from tukaan._props import focusable
+from tukaan._props import TakeFocus
 from tukaan._tcl import Tcl
 from tukaan.enums import Orientation
 from tukaan.exceptions import TclError
@@ -69,7 +69,7 @@ class Pane(Frame):
 class SplitView(WidgetBase, Container):
     _tcl_class = "ttk::panedwindow"
 
-    focusable = focusable
+    focusable = TakeFocus()
 
     def __init__(
         self,

--- a/tukaan/widgets/splitview.py
+++ b/tukaan/widgets/splitview.py
@@ -4,7 +4,7 @@ import contextlib
 from collections.abc import Iterator
 
 from tukaan._base import Container, TkWidget, WidgetBase
-from tukaan._props import TakeFocus
+from tukaan._props import FocusableProp
 from tukaan._tcl import Tcl
 from tukaan.enums import Orientation
 from tukaan.exceptions import TclError
@@ -69,7 +69,7 @@ class Pane(Frame):
 class SplitView(WidgetBase, Container):
     _tcl_class = "ttk::panedwindow"
 
-    focusable = TakeFocus()
+    focusable = FocusableProp()
 
     def __init__(
         self,

--- a/tukaan/widgets/tabview.py
+++ b/tukaan/widgets/tabview.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 from tukaan._base import Container, TkWidget, WidgetBase
 from tukaan._images import Icon, Pillow2Tcl
-from tukaan._props import _convert_padding, _convert_padding_back, FocusableProp
+from tukaan._props import FocusableProp, _convert_padding, _convert_padding_back
 from tukaan._tcl import Tcl
 from tukaan.enums import ImagePosition
 from tukaan.exceptions import TclError

--- a/tukaan/widgets/tabview.py
+++ b/tukaan/widgets/tabview.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 from tukaan._base import Container, TkWidget, WidgetBase
 from tukaan._images import Icon, Pillow2Tcl
-from tukaan._props import _convert_padding, _convert_padding_back, TakeFocus
+from tukaan._props import _convert_padding, _convert_padding_back, FocusableProp
 from tukaan._tcl import Tcl
 from tukaan.enums import ImagePosition
 from tukaan.exceptions import TclError
@@ -144,7 +144,7 @@ class Tab(Frame):
 class TabView(WidgetBase, Container):
     _tcl_class = "ttk::notebook"
 
-    focusable = TakeFocus()
+    focusable = FocusableProp()
 
     def __init__(
         self,

--- a/tukaan/widgets/tabview.py
+++ b/tukaan/widgets/tabview.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 from tukaan._base import Container, TkWidget, WidgetBase
 from tukaan._images import Icon, Pillow2Tcl
-from tukaan._props import _convert_padding, _convert_padding_back, focusable
+from tukaan._props import _convert_padding, _convert_padding_back, TakeFocus
 from tukaan._tcl import Tcl
 from tukaan.enums import ImagePosition
 from tukaan.exceptions import TclError
@@ -144,7 +144,7 @@ class Tab(Frame):
 class TabView(WidgetBase, Container):
     _tcl_class = "ttk::notebook"
 
-    focusable = focusable
+    focusable = TakeFocus()
 
     def __init__(
         self,

--- a/tukaan/widgets/textbox.py
+++ b/tukaan/widgets/textbox.py
@@ -4,7 +4,7 @@ from typing import Iterable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase, XScrollable
 from tukaan._data import Bbox
-from tukaan._props import cget, config, Foreground, TakeFocus, TextAlign, Width
+from tukaan._props import cget, config, ForegroundProp, FocusableProp, TextAlignProp, WidthProp
 from tukaan._tcl import Tcl
 from tukaan.colors import Color
 from tukaan.exceptions import TclError
@@ -13,10 +13,10 @@ from tukaan.exceptions import TclError
 class TextBox(WidgetBase, InputControl, XScrollable):
     _tcl_class = "ttk::entry"
 
-    fg_color = Foreground()
-    focusable = TakeFocus()
-    text_align = TextAlign()
-    width = Width()
+    fg_color = ForegroundProp()
+    focusable = FocusableProp()
+    text_align = TextAlignProp()
+    width = WidthProp()
 
     start = 0
     end = "end"

--- a/tukaan/widgets/textbox.py
+++ b/tukaan/widgets/textbox.py
@@ -4,7 +4,7 @@ from typing import Iterable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase, XScrollable
 from tukaan._data import Bbox
-from tukaan._props import cget, config, ForegroundProp, FocusableProp, TextAlignProp, WidthProp
+from tukaan._props import FocusableProp, ForegroundProp, TextAlignProp, WidthProp, cget, config
 from tukaan._tcl import Tcl
 from tukaan.colors import Color
 from tukaan.exceptions import TclError

--- a/tukaan/widgets/textbox.py
+++ b/tukaan/widgets/textbox.py
@@ -4,7 +4,7 @@ from typing import Iterable
 
 from tukaan._base import InputControl, TkWidget, WidgetBase, XScrollable
 from tukaan._data import Bbox
-from tukaan._props import cget, config, fg_color, focusable, text_align, width
+from tukaan._props import cget, config, Foreground, TakeFocus, TextAlign, Width
 from tukaan._tcl import Tcl
 from tukaan.colors import Color
 from tukaan.exceptions import TclError
@@ -13,10 +13,10 @@ from tukaan.exceptions import TclError
 class TextBox(WidgetBase, InputControl, XScrollable):
     _tcl_class = "ttk::entry"
 
-    fg_color = fg_color
-    focusable = focusable
-    text_align = text_align
-    width = width
+    fg_color = Foreground()
+    focusable = TakeFocus()
+    text_align = TextAlign()
+    width = Width()
 
     start = 0
     end = "end"

--- a/tukaan/widgets/window.py
+++ b/tukaan/widgets/window.py
@@ -31,8 +31,8 @@ class Window(WindowBase):
         Tcl.call(None, self._tcl_class, self._wm_path)
         Tcl.eval(None, f"pack [ttk::frame {self._name}] -expand 1 -fill both")
 
-        self._set_title(title)
-        self._set_size((width, height))
+        self.title = title
+        self.size = (width, height)
 
         Tcl.call(None, "bind", self, "<Map>", self._generate_state_event)
         Tcl.call(None, "bind", self, "<Unmap>", self._generate_state_event)


### PR DESCRIPTION
Changed many / almost all `getter` / `setter` functions to either properties or descriptors. Using descriptors for a library like this will vastly reduce boilerplate.

*This is a BIG change. I might have unknowingly broken some code, since there were a lot of type errors, but I did check for references majority of the times.*

Tbh, the descriptors are placed a little randomly across modules, as I implemented them wherever required. I think there are just too many modules. The number of modules needs to be reduced and the scope of objects (variables / constants / functions / classes / modules) needs to be better indicated by a `_` prefix to imply internal code.

Apart from this, I personally have faced a lot of issues dealing with private variables for caching and public properties for exposing them. It might have been a different case for you but, imo private variables are best avoided wherever possible.