### PR TITLE
Add window icons to the Window Manager

### DIFF
--- a/tukaan/windows/wm.py
+++ b/tukaan/windows/wm.py
@@ -107,7 +107,7 @@ def _get_bgr_color(rgb_hex: str) -> int:
 class WindowManager:
     _current_state = "normal"
     _wm_path: str
-    _icon: Icon | None = None
+    _icon: Icon | Path | None = None
 
     bind: Callable
     unbind: Callable
@@ -556,7 +556,7 @@ class WindowManager:
         self._force_redraw_titlebar()
 
     @property
-    def icon(self) -> Icon | None:
+    def icon(self) -> Icon | Path | None:
         return self._icon
 
     @icon.setter
@@ -585,7 +585,7 @@ class WindowManager:
                     temp_file = NamedTemporaryFile(delete=False)
                     PillowImage.open(icon_path.resolve()).save(temp_file.name, format="PNG")
                     win_icon = Icon(Path(temp_file.name))
-                    self._icon = win_icon
+                    self._icon = icon_path
                     Tcl.call(None, "wm", "iconphoto", self._wm_path, "-default", win_icon._name)
                 except Exception as e:
                     raise e

--- a/tukaan/windows/wm.py
+++ b/tukaan/windows/wm.py
@@ -107,7 +107,7 @@ def _get_bgr_color(rgb_hex: str) -> int:
 class WindowManager:
     _current_state = "normal"
     _wm_path: str
-    _window_icon: Icon | None = None
+    _icon: Icon | None = None
 
     bind: Callable
     unbind: Callable
@@ -457,14 +457,6 @@ class WindowManager:
             Tcl.call(None, "wm", "attributes", self._wm_path, value)
 
     @property
-    def icon(self) -> Icon:
-        return Tcl.call(Icon, "wm", "iconphoto", self._wm_path)
-
-    @icon.setter
-    def icon(self, image: Icon) -> None:
-        Tcl.call(None, "wm", "iconphoto", self._wm_path, image)
-
-    @property
     @Platform.windows_only
     def border_color(self) -> None:
         ...
@@ -564,21 +556,21 @@ class WindowManager:
         self._force_redraw_titlebar()
 
     @property
-    def window_icon(self) -> Icon | None:
-        return self._window_icon
+    def icon(self) -> Icon | None:
+        return self._icon
 
-    @window_icon.setter
-    def window_icon(self, icon: Path | Icon) -> None:
+    @icon.setter
+    def icon(self, icon: Path | Icon) -> None:
         if isinstance(icon, Icon):
             # If the icon was created, then by here Tcl/Tk has to have created a valid photo image for it
             Tcl.call(None, "wm", "iconphoto", self._wm_path, "-default", icon._name)
-            self._window_icon = icon
+            self._icon = icon
 
         else:
             icon_path = Path(icon)
             if icon_path.suffix == ".png":
                 win_icon = Icon(icon_path)
-                self._window_icon = win_icon
+                self._icon = win_icon
                 Tcl.call(None, "wm", "iconphoto", self._wm_path, "-default", win_icon._name)
             elif icon_path.suffix in (".ico", ".icns"):
                 # Tcl/Tk does not support making photo images or bitmap images directly from .ico or .icns files
@@ -593,7 +585,7 @@ class WindowManager:
                     temp_file = NamedTemporaryFile(delete=False)
                     PillowImage.open(icon_path.resolve()).save(temp_file.name, format="PNG")
                     win_icon = Icon(Path(temp_file.name))
-                    self._window_icon = win_icon
+                    self._icon = win_icon
                     Tcl.call(None, "wm", "iconphoto", self._wm_path, "-default", win_icon._name)
                 except Exception as e:
                     raise e

--- a/tukaan/windows/wm.py
+++ b/tukaan/windows/wm.py
@@ -7,6 +7,7 @@ import sys
 from enum import Enum
 from fractions import Fraction
 from typing import Callable, Sequence
+from pathlib import Path
 
 from tukaan._images import Icon
 from tukaan._misc import Position, Size
@@ -103,6 +104,7 @@ def _get_bgr_color(rgb_hex: str) -> int:
 class WindowManager:
     _current_state = "normal"
     _wm_path: str
+    _win_icon: Icon | None = None
 
     bind: Callable
     unbind: Callable
@@ -557,3 +559,17 @@ class WindowManager:
 
         self.use_dark_mode_decorations = dark
         self._force_redraw_titlebar()
+
+    @property
+    def window_icon(self) -> Icon | None:
+        return self._win_icon
+
+    @window_icon.setter
+    def window_icon(self, icon: Path | Icon) -> None:
+        if isinstance(icon, Path):
+            icon = Icon(icon)
+        # The -default flag makes the provided icon the icon for all TopLevels
+        # Might want to make this toggleable somehow.
+        # Also not totally obvious how to remove an icon,
+        # Set to be a hard coded transparent image?
+        Tcl.call(None, "wm", "iconphoto", self._wm_path, "-default", icon._name)

--- a/tukaan/windows/wm.py
+++ b/tukaan/windows/wm.py
@@ -107,7 +107,7 @@ def _get_bgr_color(rgb_hex: str) -> int:
 class WindowManager:
     _current_state = "normal"
     _wm_path: str
-    _window_icon_src: Path | None = None
+    _window_icon: Icon | None = None
 
     bind: Callable
     unbind: Callable
@@ -565,20 +565,20 @@ class WindowManager:
 
     @property
     def window_icon(self) -> Icon | None:
-        return self._window_icon_src
+        return self._window_icon
 
     @window_icon.setter
     def window_icon(self, icon: Path | Icon) -> None:
         if isinstance(icon, Icon):
             # If the icon was created, then by here Tcl/Tk has to have created a valid photo image for it
             Tcl.call(None, "wm", "iconphoto", self._wm_path, "-default", icon._name)
-            self._window_icon_src = icon.source
+            self._window_icon = icon
 
         else:
             icon_path = Path(icon)
             if icon_path.suffix == ".png":
-                self._window_icon_src = icon_path
                 win_icon = Icon(icon_path)
+                self._window_icon = win_icon
                 Tcl.call(None, "wm", "iconphoto", self._wm_path, "-default", win_icon._name)
             elif icon_path.suffix in (".ico", ".icns"):
                 # Tcl/Tk does not support making photo images or bitmap images directly from .ico or .icns files
@@ -593,6 +593,7 @@ class WindowManager:
                     temp_file = NamedTemporaryFile(delete=False)
                     PillowImage.open(icon_path.resolve()).save(temp_file.name, format="PNG")
                     win_icon = Icon(Path(temp_file.name))
+                    self._window_icon = win_icon
                     Tcl.call(None, "wm", "iconphoto", self._wm_path, "-default", win_icon._name)
                 except Exception as e:
                     raise e


### PR DESCRIPTION
Added a `window_icon @property` to `WindowManager`, with an internal `_window_icon` attribute that holds the `tukaan.Icon` instance.
As requested, it can accept any of `.png`, `.ico`, or `.icns` files (with the ability to support more file types) from either a `tukaan.Icon` or `pathlib.Path`.